### PR TITLE
#56 gmail local storage add content hash to message objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bug: fix file storage new mutation as deleted with put fail error 
 - Enh #23: extend storage interface with modify
+- Enh #56: content hash added to gmail message objects
 
 # 0.8.0
 

--- a/gwbackupy/storage/file_storage.py
+++ b/gwbackupy/storage/file_storage.py
@@ -291,7 +291,7 @@ class FileStorage(StorageInterface):
     def content_hash_add(self, link: FileLink) -> FileLink:
         try:
             with self.get(link) as f:
-                content_hash = self.generate_content_hash(f)
+                content_hash = self.content_hash_generate(f)
 
             to_link = copy.deepcopy(link)
             to_link.set_properties({LinkInterface.property_content_hash: content_hash})
@@ -315,11 +315,11 @@ class FileStorage(StorageInterface):
     def content_hash_eq(self, link: FileLink, data: IO[bytes] | bytes | str) -> bool:
         if not link.has_property(LinkInterface.property_content_hash):
             return False
-        return self.generate_content_hash(data) == link.get_property(
+        return self.content_hash_generate(data) == link.get_property(
             LinkInterface.property_content_hash
         )
 
-    def generate_content_hash(self, b: IO[bytes] | bytes | str) -> str:
+    def content_hash_generate(self, b: IO[bytes] | bytes | str) -> str:
         if isinstance(b, bytes):
             data = b
         elif isinstance(b, str):

--- a/gwbackupy/storage/file_storage.py
+++ b/gwbackupy/storage/file_storage.py
@@ -256,9 +256,6 @@ class FileStorage(StorageInterface):
                 m["path"] = _path
                 link.fill(m)
 
-                if "extension" not in m:
-                    logging.debug(f"Unknown file without extension: {file_path}")
-                    continue
                 if m["extension"] == "tmp":
                     logging.debug(f"Temporary file {file_path}, remove it")
                     try:

--- a/gwbackupy/storage/storage_interface.py
+++ b/gwbackupy/storage/storage_interface.py
@@ -156,18 +156,33 @@ class StorageInterface:
         raise NotImplementedError("StorageInterface#find")
 
     def modify(self, link: LinkInterface, to_link: LinkInterface) -> bool:
+        """
+        modify link to a new link
+        """
         raise NotImplementedError("StorageInterface#modify")
 
     def content_hash_add(self, link: LinkInterface) -> LinkInterface:
+        """
+        Add content hash to link, and return with the new link
+        """
         raise NotImplementedError("StorageInterface#content_hash_add")
 
     def content_hash_check(self, link: LinkInterface) -> bool | None:
+        """
+        Check content hash on link. If link not contain content hash then return None else return equality
+        """
         raise NotImplementedError("StorageInterface#content_hash_check")
 
     def content_hash_eq(
         self, link: LinkInterface, data: IO[bytes] | bytes | str
     ) -> bool:
+        """
+        Check content hash equality. If the link is not contain content hash then return False.
+        """
         raise NotImplementedError("StorageInterface#content_hash_eq")
 
     def content_hash_generate(self, data: IO[bytes] | bytes | str) -> str:
+        """
+        Generate content hash from input data
+        """
         raise NotImplementedError("StorageInterface#content_hash_generate")

--- a/gwbackupy/storage/storage_interface.py
+++ b/gwbackupy/storage/storage_interface.py
@@ -169,5 +169,5 @@ class StorageInterface:
     ) -> bool:
         raise NotImplementedError("StorageInterface#content_hash_eq")
 
-    def content_hash_generate(self, data: IO[bytes] | bytes | str) -> bool:
+    def content_hash_generate(self, data: IO[bytes] | bytes | str) -> str:
         raise NotImplementedError("StorageInterface#content_hash_generate")

--- a/gwbackupy/storage/storage_interface.py
+++ b/gwbackupy/storage/storage_interface.py
@@ -168,3 +168,6 @@ class StorageInterface:
         self, link: LinkInterface, data: IO[bytes] | bytes | str
     ) -> bool:
         raise NotImplementedError("StorageInterface#content_hash_eq")
+
+    def content_hash_generate(self, data: IO[bytes] | bytes | str) -> bool:
+        raise NotImplementedError("StorageInterface#content_hash_generate")

--- a/gwbackupy/tests/mock_storage.py
+++ b/gwbackupy/tests/mock_storage.py
@@ -45,12 +45,15 @@ class MockLink(LinkInterface):
             return True
         return False
 
-    def set_properties(self, sets: dict[str, any], replace: bool = False) -> FileLink:
+    def set_properties(self, sets: dict[str, any], replace: bool = False) -> MockLink:
         if replace:
             self.__properties = sets
             return self
         for k, v in sets.items():
-            self.__properties[k] = v
+            if k in self.__properties and v is None:
+                del self.__properties[k]
+            else:
+                self.__properties[k] = v
         return self
 
     def is_deleted(self) -> bool:
@@ -120,7 +123,7 @@ class MockStorage(StorageInterface):
     def modify(self, link: MockLink, to_link: MockLink) -> bool:
         for d in self.__objects:
             if d.get("link") == link:
-                d.put("link", to_link)
+                d["link"] = to_link
                 return True
         return False
 

--- a/gwbackupy/tests/mock_storage.py
+++ b/gwbackupy/tests/mock_storage.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import io
 from datetime import datetime
 from typing import IO
@@ -121,6 +122,20 @@ class MockStorage(StorageInterface):
                 d.put("link", to_link)
                 return True
         return False
+
+    def content_hash_add(self, link: LinkInterface) -> LinkInterface:
+        pass
+
+    def content_hash_check(self, link: LinkInterface) -> bool | None:
+        pass
+
+    def content_hash_generate(self, data: IO[bytes] | bytes | str) -> str:
+        return hashlib.sha1(self.data2bytes(data)).hexdigest().lower()
+
+    def content_hash_eq(
+        self, link: LinkInterface, data: IO[bytes] | bytes | str
+    ) -> bool:
+        pass
 
     def inject_get_objects(self) -> list[dict[str, any]]:
         return self.__objects

--- a/gwbackupy/tests/test_file_storage.py
+++ b/gwbackupy/tests/test_file_storage.py
@@ -296,13 +296,13 @@ def test_content_hash():
         chash = new_link.get_property(LinkInterface.property_content_hash)
         assert chash is not None
         with fs.get(new_link) as f:
-            assert chash == fs.generate_content_hash(f)
+            assert chash == fs.content_hash_generate(f)
         fs.put(new_link, "a1234")
         assert fs.content_hash_check(new_link) is False
 
         link3 = fs.new_link("test123", "ext2")
         link3.set_properties(
-            {LinkInterface.property_content_hash: fs.generate_content_hash("a1234")}
+            {LinkInterface.property_content_hash: fs.content_hash_generate("a1234")}
         )
         fs.put(link3, "a1234")
         assert fs.content_hash_check(link3) is True
@@ -341,19 +341,19 @@ def test_content_hash_check_fail():
 def test_generate_content_hash():
     with tempfile.TemporaryDirectory(prefix="myapp-") as temproot:
         fs = FileStorage(root=temproot)
-        assert fs.generate_content_hash("a1234") == "m828c88f34ecb4c1ca8d89e018c6fad1a"
+        assert fs.content_hash_generate("a1234") == "m828c88f34ecb4c1ca8d89e018c6fad1a"
         assert (
-            fs.generate_content_hash(bytes("a1234", "utf-8"))
+            fs.content_hash_generate(bytes("a1234", "utf-8"))
             == "m828c88f34ecb4c1ca8d89e018c6fad1a"
         )
         link = fs.new_link("test", "ext")
         fs.put(link, "a1234")
         assert (
-            fs.generate_content_hash(fs.get(link))
+            fs.content_hash_generate(fs.get(link))
             == "m828c88f34ecb4c1ca8d89e018c6fad1a"
         )
         try:
-            fs.generate_content_hash({})
+            fs.content_hash_generate({})
             assert False
         except RuntimeError as e:
             assert str(e).startswith("Invalid type: ")

--- a/gwbackupy/tests/test_gmail.py
+++ b/gwbackupy/tests/test_gmail.py
@@ -52,6 +52,8 @@ def test_server_backup_one_message():
                 with ms.get(link) as f:
                     assert message_raw == gzip.decompress(f.read())
                 assert link.has_property(LinkInterface.property_content_hash)
-                assert ms.content_hash_generate(message_raw) == link.get_property(LinkInterface.property_content_hash)
+                assert ms.content_hash_generate(message_raw) == link.get_property(
+                    LinkInterface.property_content_hash
+                )
     assert message_meta_found
     assert message_body_found

--- a/gwbackupy/tests/test_gmail.py
+++ b/gwbackupy/tests/test_gmail.py
@@ -55,5 +55,67 @@ def test_server_backup_one_message():
                 assert ms.content_hash_generate(message_raw) == link.get_property(
                     LinkInterface.property_content_hash
                 )
+                assert ms.content_hash_check(link)
     assert message_meta_found
     assert message_body_found
+
+
+def test_server_continuos_backup():
+    ms = MockStorage()
+    sw = MockGmailServiceWrapper()
+    message_id = random_string()
+    message_raw = bytes(f"Message body... {message_id}", "utf-8")
+    sw.inject_message(
+        {
+            "id": message_id,
+            "raw": encode_base64url(message_raw),
+            "internalDate": str(int(datetime.now().timestamp() * 1000)),
+        }
+    )
+    email = "example@example.com"
+    gmail = Gmail(
+        email=email,
+        storage=ms,
+        service_wrapper=sw,
+    )
+    assert gmail.backup()
+    message_id2 = random_string()
+    message_raw2 = bytes(f"Message body... {message_id2}", "utf-8")
+    sw.inject_message(
+        {
+            "id": message_id2,
+            "raw": encode_base64url(message_raw2),
+            "internalDate": str(int(datetime.now().timestamp() * 1000)),
+        }
+    )
+    assert gmail.backup()
+    # labels + two messages metadata + two messages object
+    assert len(ms.inject_get_objects()) == 1 + 2 + 2
+    requirements = {
+        message_id: {"metadata": False, "message": False, "message_raw": message_raw},
+        message_id2: {"metadata": False, "message": False, "message_raw": message_raw2},
+    }
+    for link in ms.find():
+        if link.id() not in requirements:
+            assert link.is_special_id()
+            continue
+        if link.is_metadata():
+            requirements[link.id()]["metadata"] = True
+        if link.is_object():
+            requirements[link.id()]["message"] = True
+            with ms.get(link) as f:
+                assert requirements[link.id()]["message_raw"] == gzip.decompress(
+                    f.read()
+                )
+            assert link.has_property(LinkInterface.property_content_hash)
+            assert ms.content_hash_generate(
+                requirements[link.id()]["message_raw"]
+            ) == link.get_property(LinkInterface.property_content_hash)
+            assert ms.content_hash_check(link)
+
+    for _id in requirements:
+        assert requirements[_id]["metadata"]
+        assert requirements[_id]["message"]
+
+
+# TODO: add tests for content hash fix BC

--- a/gwbackupy/tests/test_gmail.py
+++ b/gwbackupy/tests/test_gmail.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from gwbackupy.gmail import Gmail
 from gwbackupy.helpers import random_string, encode_base64url
+from gwbackupy.storage.storage_interface import LinkInterface
 from gwbackupy.tests.mock_storage import MockStorage
 from gwbackupy.tests.mock_gmail_service_wrapper import MockGmailServiceWrapper
 
@@ -50,5 +51,7 @@ def test_server_backup_one_message():
                 message_body_found = True
                 with ms.get(link) as f:
                     assert message_raw == gzip.decompress(f.read())
+                assert link.has_property(LinkInterface.property_content_hash)
+                assert ms.content_hash_generate(message_raw) == link.get_property(LinkInterface.property_content_hash)
     assert message_meta_found
     assert message_body_found

--- a/gwbackupy/tests/test_storage_interface.py
+++ b/gwbackupy/tests/test_storage_interface.py
@@ -36,6 +36,9 @@ def test_not_implemented_storage():
     e = get_exception(lambda: s.content_hash_eq(MockLink(), ""))
     assert isinstance(e, NotImplementedError)
     assert str(e) == "StorageInterface#content_hash_eq"
+    e = get_exception(lambda: s.content_hash_generate(""))
+    assert isinstance(e, NotImplementedError)
+    assert str(e) == "StorageInterface#content_hash_generate"
 
 
 def test_not_implemented_link():


### PR DESCRIPTION
<!-- If possible, do not create one PR for multiple issues. -->

| Q             | A
|---------------| ---
| Bugfix        | ❌
| Enhancement   | ✔️
| BC            | ✔️
| Linked issues | #56 

- [x] backup add if not exists
- [x] backup add if new
- [ ] restore check